### PR TITLE
Limit how long strings we'll unfold into char comparisons

### DIFF
--- a/src/main/java/com/humio/jitrex/compiler/RMachine.java
+++ b/src/main/java/com/humio/jitrex/compiler/RMachine.java
@@ -49,9 +49,9 @@ public abstract class RMachine {
     public static final int HINT_START_ANCHORED = 1;
     public static final int HINT_END_ANCHORED = 2;
     public static final int HINT_CHAR_STAR_HEAD = 4; // .* a* [a-z]* type head
-    public static final int FLAG_DOT_IS_ANY = Regex.DOTALL << 16; // . can by any char, not only non-newline
-    public static final int FLAG_MULTILINE  = Regex.MULTILINE << 16; // . can by any char, not only non-newline
-    public static final int FLAG_IGNORECASE = Regex.CASE_INSENSITIVE << 16; // . can by any char, not only non-newline
+    public static final int FLAG_DOT_IS_ANY = regexFlagToExtension(Regex.DOTALL); // . can by any char, not only non-newline
+    public static final int FLAG_MULTILINE  = regexFlagToExtension(Regex.MULTILINE); // . can by any char, not only non-newline
+    public static final int FLAG_IGNORECASE = regexFlagToExtension(Regex.CASE_INSENSITIVE); // . can by any char, not only non-newline
 
     public static final int EXT_HINT = 0x0001; // hint
     public static final int EXT_MULTIFORK = 0x0002; // multiFork and inc
@@ -238,8 +238,13 @@ public abstract class RMachine {
     }
 
     public void setFlags(int flags) {
-        extensions = (extensions & 0xffff) | (flags << 16);
+        extensions = (extensions & 0xffff) | regexFlagToExtension(flags);
     }
+
+    public static final int regexFlagToExtension(int flag) {
+        return flag << 16;
+    }
+
 }
 
 

--- a/src/main/java/com/humio/jitrex/jvm/JavaClassRegexStub.java
+++ b/src/main/java/com/humio/jitrex/jvm/JavaClassRegexStub.java
@@ -304,8 +304,9 @@ public abstract class JavaClassRegexStub extends Regex {
     }
 
     /**
-     * Returns true if the character at the i'th position in the input has the expected value. The index is guaranteed
-     * to be within the bounds of the string.
+     * Returns true if the character at the i'th position in the input has the
+     * expected value. The index is guaranteed to be within the bounds of the
+     * string.
      */
     protected static boolean charMatches(CharSequence input, int i, char expected) {
         return input.charAt(i) == expected;
@@ -325,17 +326,31 @@ public abstract class JavaClassRegexStub extends Regex {
     }
 
     /**
-     * Returns true if the character at the i'th position in the input has the expected value, independent of case. The
-     * index is guaranteed to be within the bounds of the string and the expected character is guaranteed to be lower
-     * case if it is alphabetical.
+     * Returns true if the character at the i'th position in the input has the
+     * expected value, independent of case. The index is guaranteed to be within
+     * the bounds of the string and the expected character is guaranteed to be
+     * lower case if it is alphabetical.
      */
     protected static boolean charMatchesInsensitive(CharSequence input, int i, char expected) {
-        return lowerCaseCharAt(input, i) == expected;
+        char ch = input.charAt(i);
+        if (ch == expected)
+            return true;
+        if (ch < 128) {
+            if (ch >= 'A' && ch <= 'Z') {
+                char lower = (char) ((int)ch + ('a' - 'A'));
+                return lower == expected;
+            } else {
+                return false;
+            }
+        } else {
+            return Character.toLowerCase(ch) == expected;
+        }
     }
 
     /**
-     * Returns true if the substring starting at the given offset in the input is the given string. It is guaranteed
-     * that the input has at least the string's length characters left after the offset.
+     * Returns true if the substring starting at the given offset in the input
+     * is the given string. It is guaranteed that the input has at least the
+     * string's length characters left after the offset.
      */
     protected static boolean substringMatches(CharSequence input, int offset, String expected) {
         int length = expected.length();
@@ -347,8 +362,9 @@ public abstract class JavaClassRegexStub extends Regex {
     }
 
     /**
-     * Returns true if the substring starting at the given offset in the input is the given string, case insensitive. It
-     * is guaranteed that the input has at least the string's length characters left after the offset.
+     * Returns true if the substring starting at the given offset in the input
+     * is the given string, case insensitive. It is guaranteed that the input
+     * has at least the string's length characters left after the offset.
      */
     protected static boolean substringMatchesInsensitive(CharSequence input, int offset, String expected) {
         int length = expected.length();

--- a/src/main/java/com/humio/jitrex/jvm/JavaClassRegexStub.java
+++ b/src/main/java/com/humio/jitrex/jvm/JavaClassRegexStub.java
@@ -303,6 +303,14 @@ public abstract class JavaClassRegexStub extends Regex {
         return cs.charAt(i);
     }
 
+    /**
+     * Returns true if the character at the i'th position in the input has the expected value. The index is guaranteed
+     * to be within the bounds of the string.
+     */
+    protected static boolean charMatches(CharSequence input, int i, char expected) {
+        return input.charAt(i) == expected;
+    }
+
     protected static char lowerCaseCharAt(CharSequence cs, int i) {
         char ch = cs.charAt(i);
         if (ch < 128) {
@@ -314,6 +322,41 @@ public abstract class JavaClassRegexStub extends Regex {
         } else {
             return Character.toLowerCase(ch);
         }
+    }
+
+    /**
+     * Returns true if the character at the i'th position in the input has the expected value, independent of case. The
+     * index is guaranteed to be within the bounds of the string and the expected character is guaranteed to be lower
+     * case if it is alphabetical.
+     */
+    protected static boolean charMatchesInsensitive(CharSequence input, int i, char expected) {
+        return lowerCaseCharAt(input, i) == expected;
+    }
+
+    /**
+     * Returns true if the substring starting at the given offset in the input is the given string. It is guaranteed
+     * that the input has at least the string's length characters left after the offset.
+     */
+    protected static boolean substringMatches(CharSequence input, int offset, String expected) {
+        int length = expected.length();
+        for (int i = 0; i < length; i++) {
+            if (!charMatches(input, offset + i, expected.charAt(i)))
+                return false;
+        }
+        return true;
+    }
+
+    /**
+     * Returns true if the substring starting at the given offset in the input is the given string, case insensitive. It
+     * is guaranteed that the input has at least the string's length characters left after the offset.
+     */
+    protected static boolean substringMatchesInsensitive(CharSequence input, int offset, String expected) {
+        int length = expected.length();
+        for (int i = 0; i < length; i++) {
+            if (!charMatchesInsensitive(input, offset + i, expected.charAt(i)))
+                return false;
+        }
+        return true;
     }
 
     protected static int cmpUnixLineTerminator(char c) {

--- a/src/main/java/com/humio/jitrex/util/Regex.java
+++ b/src/main/java/com/humio/jitrex/util/Regex.java
@@ -48,6 +48,9 @@ public abstract class Regex implements Cloneable, FilenameFilter {
     public static final int DOTALL = 0x04;
     public static final int LAZY = 0x08;
 
+    public static final int _OLD_LONG_STRING_HANDLING = 0x10;
+    public static final int _SAVE_BYTECODE = 0x20;
+
     public static Regex createRegex(String re) {
         if (factory == null)
             initFactory();

--- a/src/test/java/com/humio/jitrex/MatcherTest.java
+++ b/src/test/java/com/humio/jitrex/MatcherTest.java
@@ -2,9 +2,9 @@ package com.humio.jitrex;
 
 import com.humio.jitrex.jvm.JavaClassRegexStub;
 import com.humio.jitrex.jvm.Sample;
+import com.humio.jitrex.jvm.Sample2;
 import com.humio.jitrex.tree.CharSet;
 import com.humio.jitrex.util.Regex;
-import com.humio.jitrex.jvm.Sample2;
 import com.humio.util.jint.util.CompilerException;
 import org.junit.Assert;
 import org.junit.Ignore;
@@ -16,7 +16,8 @@ import java.lang.management.ManagementFactory;
 import java.util.*;
 
 import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 /*
 import java.util.jitrex.Pattern;
@@ -474,19 +475,11 @@ public class MatcherTest {
     public void testClassLeak() {
         // In case you need the pid for jmap this prints it.
         System.out.println("##### PROCESS: " + ManagementFactory.getRuntimeMXBean().getName() + " #####");
-        String str = "sheltercatchasmcovesilencebowltreelagoon|waterfalldewclifflightrivercatsuniceberg|" +
-                "applebedbananabirdrivercoaldawnleaves|lioncreekmistgardenduckbeachlawnautumn|" +
-                "teacherdovesunshinesoupbriarsfreezedarknessdusk|riversoilbreadfogbikesunsetchairanimal|" +
-                "starpondbeedogforestgeyserrabbitsummer|pantsearthdawncoalfernduskwaterfallfog|" +
-                "milkvalleybreezerabbitfogduckapplesnowflake|brookcliffmarshbeachabyssearthgeyserwindow|" +
-                "darknesslionreefcoastdawnwillowdoorrain|bananabranchcanopyswampauroracliffsoilcar|" +
-                "bedsparrowcerealcavelionflooddoveshirt|covesnowflakesunrisetsunamidoorflowersoulcar|" +
-                "gurugiftstormtrucktigerslagoonbedcereal|guidesandfishflowerlandcavestarcoast|" +
-                "chaircookieoceancavernbunnyshelterfloweroasis|marshmountainlionskycowwintersunpine|" +
-                "fishjuicemouseprizefarmapplefireflyfield|trainsheltermousetreereservegalaxyvolcanolagoon";
+        List<String> strings = buildLongStrings(100, 32);
+        String str = listToAlternation(strings);
         for (int i = 0; i < 1000000; i++) {
             Pattern pattern = Pattern.compile(str);
-            assertTrue(pattern.matches("sheltercatchasmcovesilencebowltreelagoon"));
+            assertTrue(pattern.matches(strings.get(i % strings.size())));
             if ((i + 1) % 1000 == 0) {
                 // Garbage collection doesn't necessarily unload classes but
                 // this should for it so you should see the heap size drop down
@@ -540,16 +533,21 @@ public class MatcherTest {
         testShortStringHeavyRegexp(true);
     }
 
-    public void testLongStringHeavyRegexp(boolean caseInsensitive) {
+    private static List<String> buildLongStrings(int count, int parts) {
         Random random = new Random(1214213);
         List<String> longWords = new ArrayList<>();
-        for (int iw = 0; iw < 100; iw++) {
+        for (int iw = 0; iw < count; iw++) {
             StringBuilder buf = new StringBuilder();
-            for (int ip = 0; ip < 8; ip++) {
+            for (int ip = 0; ip < parts; ip++) {
                 buf.append(nouns.get(random.nextInt(nouns.size())));
             }
             longWords.add(buf.toString());
         }
+        return longWords;
+    }
+
+    public void testLongStringHeavyRegexp(boolean caseInsensitive) {
+        List<String> longWords = buildLongStrings(100, 8);
         Pattern p = Pattern.compile(listToAlternation(longWords), caseInsensitive ? Pattern.CASE_INSENSITIVE : 0);
         for (String longWord : longWords) {
             assertTrue(p.matches(longWord));

--- a/src/test/java/com/humio/jitrex/MatcherTest.java
+++ b/src/test/java/com/humio/jitrex/MatcherTest.java
@@ -13,10 +13,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import java.lang.management.ManagementFactory;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.*;
@@ -500,6 +497,71 @@ public class MatcherTest {
                 System.gc();
             }
         }
+    }
+
+    private static final List<String> nouns = Arrays.asList(
+        "abyss", "animal", "apple", "atoll", "aurora", "autumn", "bacon", "badlands", "ball", "banana", "bath",
+        "beach", "bear", "bed", "bee", "bike", "bird", "boat", "book", "bowl", "branch", "bread", "breeze", "briars",
+        "brook", "brush", "bunny", "candy", "canopy", "canyon", "car", "cat", "cave", "cavern", "cereal", "chair",
+        "chasm", "chip", "cliff", "coal", "coast", "cookie", "cove", "cow", "crater", "creek", "darkness", "dawn",
+        "desert", "dew", "dog", "door", "dove", "drylands", "duck", "dusk", "earth", "fall", "farm", "fern", "field",
+        "firefly", "fish", "fjord", "flood", "flower", "flowers", "fog", "foliage", "forest", "freeze", "frog", "fu",
+        "galaxy", "garden", "geyser", "gift", "glass", "grove", "guide", "guru", "hat", "hug", "hero", "hill",
+        "horse", "house", "hurricane", "ice", "iceberg", "island", "juice", "lagoon", "lake", "land", "lawn", "leaf",
+        "leaves", "light", "lion", "marsh", "meadow", "milk", "mist", "moon", "moss", "mountain", "mouse", "nature",
+        "oasis", "ocean", "pants", "peak", "pebble", "pine", "pilot", "plane", "planet", "plant", "plateau", "pond",
+        "prize", "rabbit", "rain", "range", "reef", "reserve", "resonance", "river", "rock", "sage", "salute",
+        "sanctuary", "sand", "sands", "shark", "shelter", "shirt", "shoe", "silence", "sky", "smokescreen",
+        "snowflake", "socks", "soil", "soul", "soup", "sparrow", "spoon", "spring", "star", "stone", "storm",
+        "stream", "summer", "summit", "sun", "sunrise", "sunset", "sunshine", "surf", "swamp", "table", "teacher",
+        "temple", "thorns", "tiger", "tigers", "towel", "train", "tree", "truck", "tsunami", "tundra", "valley",
+        "volcano", "water", "waterfall", "waves", "wild", "willow", "window", "winds", "winter", "zebra");
+
+    private static String listToAlternation(List<String> items) {
+        StringBuilder buf = new StringBuilder(items.get(0));
+        for (String word : items.subList(1, items.size()))
+            buf.append("|").append(word);
+        return buf.toString();
+    }
+
+    public void testShortStringHeavyRegexp(boolean caseInsensitive) {
+        Pattern p = Pattern.compile(listToAlternation(nouns), caseInsensitive ? Pattern.CASE_INSENSITIVE : 0);
+        for (String word : nouns) {
+            assertTrue(p.matches(word));
+            if (caseInsensitive) {
+                assertTrue(p.matches(word.toUpperCase()));
+            }
+        }
+    }
+
+    @Test
+    public void testShortStringHeavyRegexp() {
+        testShortStringHeavyRegexp(false);
+        testShortStringHeavyRegexp(true);
+    }
+
+    public void testLongStringHeavyRegexp(boolean caseInsensitive) {
+        Random random = new Random(1214213);
+        List<String> longWords = new ArrayList<>();
+        for (int iw = 0; iw < 100; iw++) {
+            StringBuilder buf = new StringBuilder();
+            for (int ip = 0; ip < 8; ip++) {
+                buf.append(nouns.get(random.nextInt(nouns.size())));
+            }
+            longWords.add(buf.toString());
+        }
+        Pattern p = Pattern.compile(listToAlternation(longWords), caseInsensitive ? Pattern.CASE_INSENSITIVE : 0);
+        for (String longWord : longWords) {
+            assertTrue(p.matches(longWord));
+            if (caseInsensitive)
+                assertTrue(p.matches(longWord.toUpperCase()));
+        }
+    }
+
+    @Test
+    public void testLongStringHeavyRegexp() {
+        testLongStringHeavyRegexp(false);
+        testLongStringHeavyRegexp(true);
     }
 
 }

--- a/src/test/java/com/humio/jitrex/PerformanceTest.java
+++ b/src/test/java/com/humio/jitrex/PerformanceTest.java
@@ -83,9 +83,8 @@ public class PerformanceTest {
         for (int iter = 0; iter < ITERS; iter++) {
 
             System.out.println("---------------- ITER: " +iter+" -----------------");
-
-            System.out.println("regex | matches | `jitrex` | `com.google.re2j` | `java.util.regex`");
-            System.out.println("---   | ---     | ---      | ---               | ---  ");
+            System.out.println("regex                                            | matches | `jitrex`   | `com.google.re2j`   | `java.util.regex`");
+            System.out.println("-------------------------------------------------+---------+------------+---------------------+------------------");
 
 
 
@@ -152,7 +151,15 @@ public class PerformanceTest {
                 total3 += google_re2;
 
 
-                System.out.println(" `/"+regexes[i].replace("|", "\\|")+"/` | "+matches2+" | "+humio_jitrex+"ms | "+google_re2+"ms  ("+(100*google_re2/humio_jitrex)+"%) | "+java_util+"ms ("+(100*java_util/humio_jitrex)+"%)");
+                System.out.println(
+                        String.format("%-48s | %7s | %8sms | %8sms  (%4s%%) | %8sms (%4s%%)",
+                                ("`/" + regexes[i].replace("|", "\\|") + "/`"),
+                                matches2,
+                                humio_jitrex,
+                                google_re2,
+                                (100*google_re2/humio_jitrex),
+                                java_util,
+                                (100*java_util/humio_jitrex)));
 
                 // System.out.println("regex["+i+"], matches="+matches1+"|"+matches2+"|"+matches3+"  jitrex:"+humio_jitrex+"ms; re2j:"+google_re2+"ms; java:"+java_util+"ms"+"; speedup: "+(100*google_re2/humio_jitrex)+"%"+" / "+(100*java_util/humio_jitrex)+"%");
 


### PR DESCRIPTION
I got the impression that there was a problem with very large strings in regexps causing jitrex to generate more bytecode than the classfile format allows in a single method. This puts a limit on how long strings we're willing to unfold. If it's longer than a certain limit it's instead stored in the constant pool and instead of generating code for each character we generate a single call to a utility method that compares the input by iterating through it.

This isn't necessarily the final version, there's a lot that can be tweaked, but I'm interested in whether I've even understood the problem right and whether this looks like a reasonable way to go.