### PR TITLE
Added explicit checking of generated method size.

### DIFF
--- a/src/main/java/com/humio/jitrex/IllegalRegexException.java
+++ b/src/main/java/com/humio/jitrex/IllegalRegexException.java
@@ -2,14 +2,25 @@ package com.humio.jitrex;
 
 public class IllegalRegexException extends IllegalArgumentException {
 
-    private final BadRegexCause cause;
+    private final BadRegexCause reason;
 
     public enum BadRegexCause {
-        REGEX_TOO_LONG
+        REGEX_TOO_LONG,
+        GENERATED_CLASS_INVALID
     }
 
-    public IllegalRegexException(BadRegexCause cause, String message) {
+    public IllegalRegexException(BadRegexCause reason, String message) {
         super(message);
-        this.cause = cause;
+        this.reason = reason;
     }
+
+    public IllegalRegexException(BadRegexCause reason, String message, Throwable cause) {
+        super(message, cause);
+        this.reason = reason;
+    }
+
+    public BadRegexCause getReason() {
+        return this.reason;
+    }
+
 }

--- a/src/main/java/com/humio/jitrex/jvm/RJavaClassMachine.java
+++ b/src/main/java/com/humio/jitrex/jvm/RJavaClassMachine.java
@@ -979,7 +979,7 @@ public class RJavaClassMachine extends RMachine implements CharClassCodes, Token
                     compiledClass = (Class<JavaClassRegexStub>) loader.makeClass(thisClass, body);
                 }
             }
-        } catch (Exception e) {
+        } catch (IOException e) {
             e.printStackTrace();
         }
     }
@@ -988,7 +988,8 @@ public class RJavaClassMachine extends RMachine implements CharClassCodes, Token
         try {
             return compiledClass.getConstructor().newInstance();
         } catch (java.lang.VerifyError e) {
-            throw new IllegalRegexException(IllegalRegexException.BadRegexCause.REGEX_TOO_LONG, "given regular expression is too long");
+            throw new IllegalRegexException(IllegalRegexException.BadRegexCause.GENERATED_CLASS_INVALID,
+                    "Generated code could not be verified", e);
         } catch (InstantiationException e) {
             e.printStackTrace();
         } catch (IllegalAccessException e) {

--- a/src/main/java/com/humio/util/jint/gen/JVMClassGenerator.java
+++ b/src/main/java/com/humio/util/jint/gen/JVMClassGenerator.java
@@ -6,6 +6,7 @@
 */
 package com.humio.util.jint.gen;
 
+import com.humio.jitrex.IllegalRegexException;
 import com.humio.util.jint.constants.DefinitionConst;
 import com.humio.util.jint.constants.TokenConst;
 
@@ -425,8 +426,14 @@ public class JVMClassGenerator extends CodeGenerator implements JVMCodes {
             codeAcc.flush();
         } catch (IOException e) {
         }
+        byte[] bytecode = codeAccInt.toByteArray();
+        if (bytecode.length >= 64 * 1024) {
+            throw new IllegalRegexException(IllegalRegexException.BadRegexCause.REGEX_TOO_LONG,
+                    "Regular expression generated more than 64K bytecode");
+        }
+
         if ((currentMethod.flags & (DefinitionConst.ACC_NATIVE | DefinitionConst.ACC_ABSTRACT)) == 0) {
-            currentMethod.code = codeAccInt.toByteArray();
+            currentMethod.code = bytecode;
             if (currentMethod.code.length == 0)
                 currentMethod.code = null;
             else {

--- a/src/test/java/com/humio/jitrex/MatcherTest.java
+++ b/src/test/java/com/humio/jitrex/MatcherTest.java
@@ -37,7 +37,7 @@ public class MatcherTest {
         } catch (CompilerException e) {
             // ok //
         }
-        
+
         try {
             Pattern p = Pattern.compile("^(");
             Assert.fail("compile should fail");
@@ -560,6 +560,43 @@ public class MatcherTest {
     public void testLongStringHeavyRegexp() {
         testLongStringHeavyRegexp(false);
         testLongStringHeavyRegexp(true);
+    }
+
+    private static final String REGRESS_12012 = "^(<(?<priority>\\d+)>)?(?<@timestamp>\\S+\\s+\\S+\\s+\\S+)" +
+            "\\s+(?<host>\\S+)\\s+(?<process_name>[^\\s\\[:]+)\\[(?<pid>[^\\]]+)\\]:" +
+            "\\s+(?<client_ip>[^: ]+)(:(?<client_port>\\S+))?\\s+\\[(?<accept_date>[^\\]]+)\\]" +
+            "\\s+(?<frontend>[^\\s\\~]+)(?<tls>\\~)?\\s+(?<backend>[^\\/]+)\\/(?<server>\\S+)" +
+            "\\s+(?<timers>\\S+)\\s+(?<status_code>\\S+)\\s+(?<bytes_read>\\S+)\\s+(?<caputred_request_cookie>\\S+)" +
+            "\\s+(?<caputred_response_cookie>\\S+)\\s+(?<termination_state>\\S+)\\s+(?<actconn>[^\\s\\/]+)\\/" +
+            "(?<feconn>[^\\s\\/]+)\\/(?<beconn>[^\\s\\/]+)\\/(?<src_conn>[^\\s\\/]+)\\/(?<retries>[^\\s\\/]+)" +
+            "\\s+(?<srv_queue>[^\\s\\/]+)\\/(?<backend_queue>[^\\s\\/]+)\\s+(\\{(?<captured_request_headers>[^\\}\\{]*)\\}" +
+            "\\s+(\\{(?<captured_response_headers>[^}]*)\\}\\s+)?)?\\\"(?<http_request>.*)\\\"";
+
+    @Test
+    public void testCharClassHeavy() {
+        Pattern.compile(REGRESS_12012);
+    }
+
+    @Test()
+    public void testTooMuchBytecode() {
+        try {
+            Pattern.compile(REGRESS_12012, Pattern.CASE_INSENSITIVE);
+            Assert.fail();
+        } catch (IllegalRegexException ire) {
+            assertEquals(IllegalRegexException.BadRegexCause.REGEX_TOO_LONG, ire.getReason());
+        }
+    }
+
+    @Ignore("Crashes code generation")
+    @Test
+    public void testRepeatOfDeath() {
+        Pattern.compile("(?:abc){10}{10}{10}{10}{10}{10}{10}{10}{10}{10}{10}{10}{10}{10}");
+    }
+
+    @Ignore("Crashes code generation")
+    @Test
+    public void testCharClassOfDeath() {
+        Pattern.compile("[^:/?#]").matches("uggc://jjj.snprobbx.pbz/ybtva.cuc");
     }
 
 }


### PR DESCRIPTION
So we don't have to wait for the verifier to find the problem. Also, added ignored test cases for some crash bugs, one of which I found trying to reproduce the problem from #12012. I won't try to fix those out of fear that for each one I fix I'll again discover several more, leading to nontermination of the entire effort.

(Ahe: feel free to pass this review on if there's someone else who seems more relevant)