### PR TITLE
Negative lookaheads do not make a regexp anchored

### DIFF
--- a/src/main/java/com/humio/jitrex/tree/RLookAheadNode.java
+++ b/src/main/java/com/humio/jitrex/tree/RLookAheadNode.java
@@ -49,7 +49,7 @@ public class RLookAheadNode extends RNode {
     }
 
     public boolean isStartAnchored() {
-        return (tail != null && tail.isStartAnchored()) || (body != null && body.isStartAnchored());
+        return (tail != null && tail.isStartAnchored()) || (positive && body != null && body.isStartAnchored());
     }
 
     public boolean hasPicks() {

--- a/src/main/java/com/humio/jitrex/tree/RNode.java
+++ b/src/main/java/com/humio/jitrex/tree/RNode.java
@@ -57,7 +57,7 @@ public abstract class RNode {
 
     /**
      * Number of variables to be used by this jitrex. This should be upper bound,
-     * but, of cource, it should be as close as possible to what RCompiler will
+     * but, of course, it should be as close as possible to what RCompiler will
      * generate.
      */
     public int getNCells() {

--- a/src/test/java/com/humio/jitrex/MatcherTest.java
+++ b/src/test/java/com/humio/jitrex/MatcherTest.java
@@ -587,6 +587,21 @@ public class MatcherTest {
         }
     }
 
+    @Test
+    public void testAnchored() {
+        patt = Pattern.compile("(?!^.o.)b.r");
+        assertEquals(true, patt.matcher("bar").find());
+        assertEquals(false, patt.matcher("bor").find());
+        assertEquals(true, patt.matcher("foo bar").find());
+        assertEquals(true, patt.matcher("foo bor").find());
+        assertEquals(true, patt.matcher("  bar").find());
+        assertEquals(true, patt.matcher("  bor").find());
+        assertEquals(true, patt.matcher(" bar ").find());
+        assertEquals(true, patt.matcher(" bor ").find());
+        assertEquals(true, patt.matcher("barbar").find());
+        assertEquals(true, patt.matcher("borbor").find());
+    }
+
     @Ignore("Crashes code generation")
     @Test
     public void testRepeatOfDeath() {


### PR DESCRIPTION
I was just taking a look at how this works, and this jumped out at me.