### PR TITLE
Some diagnostics and cleanup of code generation

### DIFF
--- a/src/main/java/com/humio/jitrex/jvm/RJavaClassMachine.java
+++ b/src/main/java/com/humio/jitrex/jvm/RJavaClassMachine.java
@@ -217,6 +217,13 @@ public class RJavaClassMachine extends RMachine implements CharClassCodes, Token
         return ++counter;
     }
 
+    /**
+     * Encodes an arbitrary string as a valid java identifier. To decode the
+     * result you can use this command:
+     *
+     * echo "2_2b_3a_5ba_2df_5d_2a_3fx_2a_20" | python -c "import re, sys; print(re.sub(r'_(..)', lambda m: chr(int(m.group(1), 16)), sys.stdin.readlines()[0]))"
+     * 2+:[a-f]*?x*
+     */
     public static String encodeAsIdentifier(String str) {
         StringBuilder buf = new StringBuilder();
         for (byte b : str.getBytes(StandardCharsets.UTF_8)) {

--- a/src/main/java/com/humio/jitrex/jvm/RLocalAllocator.java
+++ b/src/main/java/com/humio/jitrex/jvm/RLocalAllocator.java
@@ -6,8 +6,20 @@
 */
 package com.humio.jitrex.jvm;
 
+import com.humio.util.jint.gen.LocalVariable;
+
 public abstract class RLocalAllocator {
+
     public abstract int alloc();
 
     public abstract void free(int local);
+
+    public LocalVariable allocVariable(String type) {
+        return new LocalVariable(alloc(), type);
+    }
+
+    public void free(LocalVariable var) {
+        free(var.getIndex());
+    }
+
 }

--- a/src/main/java/com/humio/util/jint/constants/MiniErrorCodes.java
+++ b/src/main/java/com/humio/util/jint/constants/MiniErrorCodes.java
@@ -59,4 +59,8 @@ public interface MiniErrorCodes {
     int ERR_F_INCOMPLETE = ERR_MASK_FORMAT | ERR_MASK_ERROR | 0x005;
     int ERR_F_NOTWITHJAVA = ERR_MASK_FORMAT | ERR_MASK_ERROR | 0x006;
 
+    // compiler codes
+
+    int ERR_C_LOCVAR_TYPING = ERR_MASK_COMPILER | ERR_MASK_ERROR;
+
 }

--- a/src/main/java/com/humio/util/jint/gen/CodeGenerator.java
+++ b/src/main/java/com/humio/util/jint/gen/CodeGenerator.java
@@ -123,11 +123,13 @@ public class CodeGenerator implements DefinitionConst, TokenConst {
         out.println("\tputstatic " + clazz + " " + name + " " + type);
     }
 
-    public void store(int var, String type) throws IOException {
+    public void store(LocalVariable var, String type) throws IOException {
+        var.typeCheck(type);
         out.println("\tstore " + var + " " + type);
     }
 
-    public void load(int var, String type) throws IOException {
+    public void load(LocalVariable var, String type) throws IOException {
+        var.typeCheck(type);
         out.println("\tload " + var + " " + type);
     }
 
@@ -155,7 +157,8 @@ public class CodeGenerator implements DefinitionConst, TokenConst {
         out.println("\tputelement " + type);
     }
 
-    public void iinc(int var, int n) throws IOException {
+    public void iinc(LocalVariable var, int n) throws IOException {
+        var.typeCheck("I");
         out.println("\tiinc " + var + " " + n);
     }
 
@@ -256,6 +259,11 @@ public class CodeGenerator implements DefinitionConst, TokenConst {
 
     public void jsr(AbstractMark mark, int stackChange) throws IOException {
         out.println("\tjsr " + mark + " " + stackChange);
+    }
+
+    public void ret(LocalVariable var) throws IOException {
+        var.typeCheck("L");
+        ret(var.getIndex());
     }
 
     public void ret(int var) throws IOException {

--- a/src/main/java/com/humio/util/jint/gen/LocalVariable.java
+++ b/src/main/java/com/humio/util/jint/gen/LocalVariable.java
@@ -1,0 +1,30 @@
+package com.humio.util.jint.gen;
+
+import com.humio.util.jint.constants.MiniErrorCodes;
+import com.humio.util.jint.util.CompilerException;
+
+public class LocalVariable {
+
+    private final int index;
+    private final String type;
+
+    public LocalVariable(int index, String type) {
+        this.index = index;
+        this.type = type;
+    }
+
+    public int getIndex() {
+        return this.index;
+    }
+
+    public String getType() {
+        return this.type;
+    }
+
+    public void typeCheck(String usageType) {
+        if (!this.type.equals(usageType)) {
+            throw new CompilerException(MiniErrorCodes.ERR_C_LOCVAR_TYPING, -1, null, new Object[] {type, usageType});
+        }
+    }
+
+}

--- a/src/main/resources/com/humio/util/jint/util/errors.txt
+++ b/src/main/resources/com/humio/util/jint/util/errors.txt
@@ -128,6 +128,7 @@ ERR_C_PRIMELEM		Cannot apply [..] to primitive type
 ERR_C_PICKEDNONSTR	Can pick only String or CharString variables
 ERR_C_MATCHARG1		Left argument in matching must be Any, String, char[] or CharString
 ERR_C_DUPCASE		Duplicate case label
+ERR_C_LOCVAR_TYPING	Local variable of type %s used under type %s
 
 ERR_C_INTERNAL		Internal error: %s
 ERR_C_NESTING		Nesting problems

--- a/src/test/java/com/humio/jitrex/jvm/RJavaClassMachineTest.java
+++ b/src/test/java/com/humio/jitrex/jvm/RJavaClassMachineTest.java
@@ -1,0 +1,19 @@
+package com.humio.jitrex.jvm;
+
+import junit.framework.TestCase;
+
+public class RJavaClassMachineTest extends TestCase {
+
+    public void testEncodeAsIdentifier() {
+        assertEquals(RJavaClassMachine.encodeAsIdentifier(".*"), "_2e_2a");
+        assertEquals(RJavaClassMachine.encodeAsIdentifier("a b c"), "a_20b_20c");
+        assertEquals(RJavaClassMachine.encodeAsIdentifier("a_b_c"), "a_5fb_5fc");
+        assertEquals(RJavaClassMachine.encodeAsIdentifier("funkyChicken"), "funkyChicken");
+    }
+
+    public void testCrc32() {
+        assertEquals(RJavaClassMachine.crc32(".*"), "9165d205");
+        assertEquals(RJavaClassMachine.crc32("funkyChicken"), "4b3f0849");
+    }
+
+}


### PR DESCRIPTION
This PR does two things.

It embeds more information about the regexp in the class name which we can see in the jvm error report when it crashes. Where before the class would be called something like

```
com.humio.jitrex.R_tmp_1
```

It might now be called

```
com.humio.jitrex.R_tmp_13_d60085fb_1_2_2b_3a_5ba_2df_5d_2a_3fx_2a_20
```

What this name means is:

- The input was `13` characters long.
- The crc32 of the input is `d60085fb`.
- The sequence number of the regexp is `1`.
- The escaped utf8 encoding of the regexp is `2_2b_3a_5ba_2df_5d_2a_3fx_2a_20` which corresponds to `2+:[a-f]*?x*`. 

To unescape the regexp you can use this,

```
$ echo "2_2b_3a_5ba_2df_5d_2a_3fx_2a_20" | python -c "import re, sys; print(re.sub(r'_(..)', lambda m: chr(int(m.group(1), 16)), sys.stdin.readlines()[0]))"
2+:[a-f]*?x* 

```

It also changes code generation to never store different types in the same local variable. Mixing types in that way isn't illegal but it's something other bytecode generators are unlikely to produce so it may land us in jvm compiler code that doesn't see much use and may be rotting. So it may remove a source of potential crashes.